### PR TITLE
`GitHubAPIClient`: throw standard HTTP errors

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -1,16 +1,18 @@
 {
   "version": "2",
   "remote": {
-    "https://cdn.skypack.dev/-/fast-json-patch@v3.1.1-IjacxII42OC4A6OXhkDe/dist=es2019,mode=imports/optimized/fast-json-patch.js": "8a50032720ec865d4ee159b727c3b6768cff79d0bc9d4596322a54bed52886a9",
-    "https://cdn.skypack.dev/-/fast-json-patch@v3.1.1-IjacxII42OC4A6OXhkDe/dist=es2019,mode=types/index.d.ts": "14fff1730ea6278c5b85b33248b881df9405c65276fe9f9964b0ce2e8dc1a71b",
-    "https://cdn.skypack.dev/-/fast-json-patch@v3.1.1-IjacxII42OC4A6OXhkDe/dist=es2019,mode=types/module/core.d.ts": "954469f78687603c8b091f09dad4ee2ce3420ad114629ccd5cc721253748446c",
-    "https://cdn.skypack.dev/-/fast-json-patch@v3.1.1-IjacxII42OC4A6OXhkDe/dist=es2019,mode=types/module/duplex.d.ts": "c5f820d4b6245fd5f9f841f8893d1f7d56a9cefcbed60eb6ed4f8de4587a8cb0",
-    "https://cdn.skypack.dev/-/fast-json-patch@v3.1.1-IjacxII42OC4A6OXhkDe/dist=es2019,mode=types/module/helpers.d.ts": "ebf6e19cb84d78da20d022a95f05e8aef12e56f816a1ee12835a4da40d7b14cf",
-    "https://cdn.skypack.dev/fast-json-patch@3.1.1/index.mjs?dts": "b2288dcad47c0abbf26e9535140b2cbae71b46c30225c1978e73b16453bb2412",
-    "https://deno.land/std@0.188.0/fmt/colors.ts": "d67e3cd9f472535241a8e410d33423980bec45047e343577554d3356e1f0ef4e",
-    "https://deno.land/std@0.188.0/testing/_diff.ts": "1a3c044aedf77647d6cac86b798c6417603361b66b54c53331b312caeb447aea",
-    "https://deno.land/std@0.188.0/testing/_format.ts": "a69126e8a469009adf4cf2a50af889aca364c349797e63174884a52ff75cf4c7",
-    "https://deno.land/std@0.188.0/testing/asserts.ts": "e16d98b4d73ffc4ed498d717307a12500ae4f2cbe668f1a215632d19fcffc22f",
-    "https://deno.land/x/github_api_types@2023-05-17-05-41/mod.ts": "dc3a5cd3176c78085b49601e9c3fccac24809b037929230293255edabafbd0bb"
+    "https://deno.land/std@0.177.1/fmt/colors.ts": "938c5d44d889fb82eff6c358bea8baa7e85950a16c9f6dae3ec3a7a729164471",
+    "https://deno.land/std@0.177.1/http/http_errors.ts": "57169d9bdf4cda1982a3742693c146ab1bf2cbc88df003b40ac905a30013d4cb",
+    "https://deno.land/std@0.177.1/http/http_status.ts": "8a7bcfe3ac025199ad804075385e57f63d055b2aed539d943ccc277616d6f932",
+    "https://deno.land/std@0.177.1/testing/_diff.ts": "1a3c044aedf77647d6cac86b798c6417603361b66b54c53331b312caeb447aea",
+    "https://deno.land/std@0.177.1/testing/_format.ts": "a69126e8a469009adf4cf2a50af889aca364c349797e63174884a52ff75cf4c7",
+    "https://deno.land/std@0.177.1/testing/asserts.ts": "984ab0bfb3faeed92ffaa3a6b06536c66811185328c5dd146257c702c41b01ab",
+    "https://deno.land/x/github_api_types@2023-05-17-05-41/mod.ts": "dc3a5cd3176c78085b49601e9c3fccac24809b037929230293255edabafbd0bb",
+    "https://esm.sh/fast-json-patch@3.1.1": "fd59bab1fabdb3e7e2ce8204aa92113dc451708797021fff6f96b8ff265faedf",
+    "https://esm.sh/v124/fast-json-patch@3.1.1/deno/fast-json-patch.mjs": "19183b256388e7af3ffb65022a634e00109c308fe79071cd550dd5ab1f0a571b",
+    "https://esm.sh/v124/fast-json-patch@3.1.1/index.d.ts": "45f4ae0bb249e9b5ee4dbaf6a6cd081e25af916237e8322125408c25e791ed72",
+    "https://esm.sh/v124/fast-json-patch@3.1.1/module/core.d.ts": "954469f78687603c8b091f09dad4ee2ce3420ad114629ccd5cc721253748446c",
+    "https://esm.sh/v124/fast-json-patch@3.1.1/module/duplex.d.ts": "c5f820d4b6245fd5f9f841f8893d1f7d56a9cefcbed60eb6ed4f8de4587a8cb0",
+    "https://esm.sh/v124/fast-json-patch@3.1.1/module/helpers.d.ts": "ebf6e19cb84d78da20d022a95f05e8aef12e56f816a1ee12835a4da40d7b14cf"
   }
 }

--- a/deps.ts
+++ b/deps.ts
@@ -1,6 +1,11 @@
+export {
+  errors,
+  isHttpError,
+} from "https://deno.land/std@0.177.1/http/http_errors.ts";
+
 export * from "https://deno.land/x/github_api_types@2023-05-17-05-41/mod.ts";
 
 export {
   applyPatch as applyJSONPatch,
   type Operation as JSONPatchOperation,
-} from "https://cdn.skypack.dev/fast-json-patch@3.1.1/index.mjs?dts";
+} from "https://esm.sh/fast-json-patch@3.1.1";

--- a/deps.ts
+++ b/deps.ts
@@ -1,7 +1,4 @@
-export {
-  errors,
-  isHttpError,
-} from "https://deno.land/std@0.177.1/http/http_errors.ts";
+export { errors } from "https://deno.land/std@0.177.1/http/http_errors.ts";
 
 export * from "https://deno.land/x/github_api_types@2023-05-17-05-41/mod.ts";
 

--- a/dev_deps.ts
+++ b/dev_deps.ts
@@ -1,1 +1,1 @@
-export { assertEquals } from "https://deno.land/std@0.188.0/testing/asserts.ts";
+export { assertEquals } from "https://deno.land/std@0.177.1/testing/asserts.ts";

--- a/github/api/github_api_client.ts
+++ b/github/api/github_api_client.ts
@@ -57,7 +57,7 @@ export class GitHubAPIClient implements GitHubAPIClientInterface {
     this.fetch = fetcher;
   }
 
-  public async getRawFile(r: GitHubAPIRawFileGetRequest): Promise<string> {
+  public async getRawText(r: GitHubAPIRawFileGetRequest): Promise<string> {
     const url = makeRawFileURL(
       this.options.owner,
       this.options.repo,
@@ -75,6 +75,39 @@ export class GitHubAPIClient implements GitHubAPIClientInterface {
     switch (response.status) {
       case 200: {
         return await response.text();
+      }
+
+      case 404: {
+        throw new errors.NotFound(await response.text());
+      }
+
+      default: {
+        throw new Error(
+          `Failed to get raw file ${this.options.owner}/${this.options.repo}/${r.branch}/${r.path}. ${await response
+            .text()}`,
+        );
+      }
+    }
+  }
+
+  public async getRawBlob(r: GitHubAPIRawFileGetRequest): Promise<Blob> {
+    const url = makeRawFileURL(
+      this.options.owner,
+      this.options.repo,
+      r.branch,
+      r.path,
+    );
+    const response = await this.fetch(url, {
+      method: "GET",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `token ${this.options.token}`,
+      },
+    });
+
+    switch (response.status) {
+      case 200: {
+        return await response.blob();
       }
 
       case 404: {

--- a/github/api/github_api_client_interface.ts
+++ b/github/api/github_api_client_interface.ts
@@ -9,9 +9,14 @@ import type { paths } from "../../deps.ts";
  */
 export interface GitHubAPIClientInterface {
   /**
-   * getRawFile gets a raw file from the repository.
+   * getRawText gets a raw file from the repository.
    */
-  getRawFile(r: GitHubAPIRawFileGetRequest): Promise<string>;
+  getRawText(r: GitHubAPIRawFileGetRequest): Promise<string>;
+
+  /**
+   * getRawBlob gets a raw blob from the repository.
+   */
+  getRawBlob(r: GitHubAPIRawFileGetRequest): Promise<Blob>;
 
   /**
    * Gets the default branch name if not passed in by the user.

--- a/github/api/github_api_client_interface.ts
+++ b/github/api/github_api_client_interface.ts
@@ -11,7 +11,7 @@ export interface GitHubAPIClientInterface {
   /**
    * getRawFile gets a raw file from the repository.
    */
-  getRawFile(r: GitHubAPIRawFileGetRequest): Promise<Response>;
+  getRawFile(r: GitHubAPIRawFileGetRequest): Promise<string>;
 
   /**
    * Gets the default branch name if not passed in by the user.
@@ -33,6 +33,9 @@ export interface GitHubAPIClientInterface {
 
   /**
    * Uploads a blob. The new blob SHA is returned.
+   *
+   * See:
+   * https://docs.github.com/en/rest/reference/git#create-a-blob
    */
   postBlobs(
     r: GitHubAPIBlobsPostRequest,
@@ -79,6 +82,14 @@ export interface GitHubAPIClientInterface {
   ): Promise<GitHubAPIRefPatchResponse>;
 
   /**
+   * getPulls gets a filtered list of PRs.
+   *
+   * See:
+   * https://docs.github.com/en/rest/reference/pulls#list-pull-requests
+   */
+  getPulls(r: GitHubAPIPullsGetRequest): Promise<GitHubAPIPullsGetResponse>;
+
+  /**
    * Creates a new PR. The new PR number is returned.
    *
    * See:
@@ -87,6 +98,16 @@ export interface GitHubAPIClientInterface {
   postPulls(
     r: GitHubAPIPullsPostRequest,
   ): Promise<GitHubAPIPullsPostResponse>;
+
+  /**
+   * Updates an existing PR.
+   *
+   * See:
+   * https://docs.github.com/en/rest/reference/pulls#update-a-pull-request
+   */
+  patchPull(
+    r: GitHubAPIPullPatchRequest,
+  ): Promise<GitHubAPIPullPatchResponse>;
 }
 
 export interface GitHubAPIRawFileGetRequest {
@@ -186,8 +207,16 @@ export type GitHubAPIPullsPostResponse =
     "content"
   ]["application/json"];
 
-export type GitHubAPIPullsPullNumberPatchRequest =
-  & { pull_number: number }
+export type GitHubAPIPullsGetRequest =
+  paths["/repos/{owner}/{repo}/pulls"]["get"]["parameters"]["query"];
+
+export type GitHubAPIPullsGetResponse =
+  paths["/repos/{owner}/{repo}/pulls"]["get"]["responses"]["200"][
+    "content"
+  ]["application/json"];
+
+export type GitHubAPIPullPatchRequest =
+  & { head: string }
   & Exclude<
     paths["/repos/{owner}/{repo}/pulls/{pull_number}"]["patch"]["requestBody"],
     undefined
@@ -195,7 +224,7 @@ export type GitHubAPIPullsPullNumberPatchRequest =
     "content"
   ]["application/json"];
 
-export type GitHubAPIPullsPullNumberPatchResponse =
+export type GitHubAPIPullPatchResponse =
   paths["/repos/{owner}/{repo}/pulls/{pull_number}"]["patch"]["responses"][
     "200"
   ]["content"]["application/json"];

--- a/github/api/github_api_client_urls.ts
+++ b/github/api/github_api_client_urls.ts
@@ -55,6 +55,15 @@ export function makePullsURL(
   return new URL(`/repos/${owner}/${repo}/pulls`, GITHUB_API_URL);
 }
 
+/** makePullURL returns the desired URL. */
+export function makePullURL(
+  owner: string,
+  repo: string,
+  pullNumber: number,
+) {
+  return new URL(`/repos/${owner}/${repo}/pulls/${pullNumber}`, GITHUB_API_URL);
+}
+
 /** makeRawFileURL returns the desired URL. */
 export function makeRawFileURL(
   owner: string,

--- a/github/tree/create.ts
+++ b/github/tree/create.ts
@@ -107,8 +107,7 @@ export async function uploadCodemodAsTreeItem(
     case GitHubCodemodType.EDIT_BLOB: {
       const blob = await api.postBlobs({
         encoding: "base64",
-        content: await api.getRawFile({ branch, path })
-          .then((response) => response.blob())
+        content: await api.getRawBlob({ branch, path })
           .then(codemod.fn)
           .then(stringFromBlob),
       });
@@ -123,8 +122,7 @@ export async function uploadCodemodAsTreeItem(
     case GitHubCodemodType.EDIT_TEXT: {
       const blob = await api.postBlobs({
         encoding: "utf-8",
-        content: await api.getRawFile({ branch, path })
-          .then((response) => response.text())
+        content: await api.getRawText({ branch, path })
           .then(codemod.fn),
       });
       return {


### PR DESCRIPTION
Uses <https://deno.land/std/http/http_errors.ts> to throw errors which can later be `catch`'d and tested against the `instanceof` keyword.

Aims to resolve #9.