### PR TITLE
Add support for ref fallbacks

### DIFF
--- a/examples/05_create_or_update_branch/main.ts
+++ b/examples/05_create_or_update_branch/main.ts
@@ -25,7 +25,10 @@ async function main() {
       })
       .createCommit(
         ({ 0: tree }) => ({ message: "Add main.ts", tree: tree.sha }),
-        (commit) => commit.parentRef("new-branch"),
+        (commit) =>
+          commit
+            .parentRef("new-branch")
+            .defaultParent(),
       )
       .createOrUpdateBranch(({ 1: commit }) => ({
         ref: "new-branch",

--- a/examples/05_create_or_update_branch/main.ts
+++ b/examples/05_create_or_update_branch/main.ts
@@ -25,10 +25,7 @@ async function main() {
       })
       .createCommit(
         ({ 0: tree }) => ({ message: "Add main.ts", tree: tree.sha }),
-        (commit) =>
-          commit
-            .parentRef("new-branch")
-            .defaultParent(),
+        (commit) => commit.parentRef("new-branch"),
       )
       .createOrUpdateBranch(({ 1: commit }) => ({
         ref: "new-branch",

--- a/github/commit/github_create_commit_builder.ts
+++ b/github/commit/github_create_commit_builder.ts
@@ -55,7 +55,7 @@ export class GitHubCreateCommitBuilder
 
             throw error;
           })
-        )?.commit.commit.tree.sha;
+        )?.commit.sha;
 
         // If sha is defined, break out of the loop.
         if (sha !== undefined) {

--- a/github/commit/github_create_commit_builder.ts
+++ b/github/commit/github_create_commit_builder.ts
@@ -15,7 +15,8 @@ export class GitHubCreateCommitBuilder
   #message: Generate<string, []>;
   #tree: Generate<string, []>;
   #parents: Generate<string[] | undefined, []>;
-  #parentRef: Generate<string | undefined, []>;
+  #parentRef: Generate<string | undefined | null, []>;
+  #fallbackRefs: Generate<string | undefined, []>[] = [];
   #defaultParent: Generate<boolean, []> = false;
   #author: Generate<GitHubAPICommitsPostRequest["author"], []>;
   #committer: Generate<GitHubAPICommitsPostRequest["committer"], []>;
@@ -95,8 +96,12 @@ export class GitHubCreateCommitBuilder
     return this;
   }
 
-  public parentRef(parentRefOrParentGenerate: Generate<string, []>): this {
+  public parentRef(
+    parentRefOrParentGenerate: Generate<string | undefined | null, []>,
+    ...fallbackRefs: Generate<string | undefined, []>[]
+  ): this {
     this.#parentRef = parentRefOrParentGenerate;
+    this.#fallbackRefs = fallbackRefs;
     return this;
   }
 

--- a/github/commit/github_create_commit_builder_interface.ts
+++ b/github/commit/github_create_commit_builder_interface.ts
@@ -33,7 +33,10 @@ export interface GitHubCreateCommitBuilderInterface {
    *
    * Subsequent calls to parent will override the previous value.
    */
-  parentRef(parentRefOrParentGenerate: Generate<string | undefined, []>): this;
+  parentRef(
+    parentRefOrParentGenerate: Generate<string | undefined | null, []>,
+    ...fallbackRefs: Generate<string | undefined, []>[]
+  ): this;
 
   /**
    * defaultParent sets the parent to the default repository branch.

--- a/github/commit/github_create_commit_builder_interface.ts
+++ b/github/commit/github_create_commit_builder_interface.ts
@@ -39,13 +39,6 @@ export interface GitHubCreateCommitBuilderInterface {
   ): this;
 
   /**
-   * defaultParent sets the parent to the default repository branch.
-   */
-  defaultParent(
-    defaultParentOrDefaultParentGenerate?: Generate<boolean, []>,
-  ): this;
-
-  /**
    * author sets the author.
    */
   author(

--- a/github/tree/github_create_tree_builder.ts
+++ b/github/tree/github_create_tree_builder.ts
@@ -26,8 +26,8 @@ import { stringFromBlob } from "./base64.ts";
  */
 export class GitHubCreateTreeBuilder
   implements GitHubCreateTreeBuilderInterface {
-  #baseTree: Generate<string | undefined, []>;
-  #baseRef: Generate<string | undefined, []>;
+  #baseRef: Generate<string | undefined | null, []>;
+  #fallbackRefs: Generate<string | undefined, []>[] = [];
   #tree: Map<string, GitHubTreeOp> = new Map();
 
   constructor(
@@ -35,10 +35,33 @@ export class GitHubCreateTreeBuilder
   ) {}
 
   public async run(): Promise<GitHubAPITreesPostRequest> {
-    let sha = await generate(this.#baseTree);
-    const ref = await generate(this.#baseRef) ??
-      (await this.api.getRepository()).default_branch;
-    sha ??= (await this.api.getBranch({ ref })).commit.commit.tree.sha;
+    let ref = await generate(this.#baseRef);
+    let sha: string | undefined;
+
+    // Use fallback refs if the base ref is undefined.
+    const fallbackRefs = this.#fallbackRefs.slice();
+    do {
+      sha = !ref ? undefined : (
+        await this.api.getBranch({ ref }).catch((error) => {
+          if (error instanceof errors.NotFound) {
+            return undefined;
+          }
+
+          throw error;
+        })
+      )?.commit.commit.tree.sha;
+
+      if (sha !== undefined) {
+        break;
+      }
+
+      ref = await generate(fallbackRefs.shift() ?? (() => undefined));
+    } while (sha === undefined && fallbackRefs.length > 0);
+
+    // Set ref to undefined if the base ref is null.
+    ref ??= undefined;
+
+    // Generate a tree.
     const tree = await doTreeOps(this.api, ref, this.#tree);
     return makeGitHubAPITreesPostRequest(sha, tree);
   }
@@ -48,19 +71,12 @@ export class GitHubCreateTreeBuilder
     return this;
   }
 
-  public baseTree(
-    shaOrSHAGenerate: Generate<string | undefined, []>,
-    baseRefOrBaseRefGenerate: Generate<string | undefined, []>,
-  ): this {
-    this.#baseTree = shaOrSHAGenerate;
-    this.#baseRef = baseRefOrBaseRefGenerate;
-    return this;
-  }
-
   public baseRef(
-    baseRefOrBaseRefGenerate: Generate<string | undefined, []>,
+    refOrRefGenerate?: Generate<string | undefined | null, []>,
+    ...fallbackRefs: Generate<string | undefined, []>[]
   ): this {
-    this.#baseRef = baseRefOrBaseRefGenerate;
+    this.#baseRef = refOrRefGenerate;
+    this.#fallbackRefs = fallbackRefs;
     return this;
   }
 
@@ -177,7 +193,7 @@ export function makeGitHubAPITreesPostRequest(
  */
 export function doTreeOps(
   api: GitHubAPIClientInterface,
-  ref: string,
+  ref: string | undefined,
   tree: Map<string, GitHubTreeOp>,
 ): Promise<GitHubAPITreesPostRequest["tree"]> {
   const ops = [...tree.entries()];
@@ -192,7 +208,7 @@ export function doTreeOps(
  */
 export function doTreeOp(
   api: GitHubAPIClientInterface,
-  ref: string,
+  ref: string | undefined,
   path: string,
   op: GitHubTreeOp,
 ): Promise<GitHubAPITreesPostRequest["tree"]> {
@@ -403,7 +419,7 @@ export async function doTreeSymlinkOp(
  */
 export async function doTreeRenameOp(
   api: GitHubAPIClientInterface,
-  ref: string,
+  ref: string | undefined,
   path: string,
   op: GitHubTreeRenameOp,
 ): Promise<GitHubAPITreesPostRequest["tree"]> {

--- a/github/tree/github_create_tree_builder_interface.ts
+++ b/github/tree/github_create_tree_builder_interface.ts
@@ -20,25 +20,35 @@ export interface GitHubCreateTreeBuilderInterface {
   clear(): this;
 
   /**
-   * base sets the base commit tree SHA.
+   * baseRef sets the base reference for a branch.
    *
-   * Subsequent calls to baseRef will override the previous value.
+   * The `baseRef` function allows for setting the base reference of a branch
+   * in a software development context. By calling this function, subsequent
+   * calls can override the previous value set for the base reference. The
+   * function takes two parameters:
+   * - `refOrRefGenerate` (optional): This parameter accepts a generator
+   *   function that returns a candidate branch name or reference. The
+   *   return type of this function can be a string, undefined, or null.
+   * - `fallbackRefs` (optional): An array of generator functions that return
+   *   candidate branch names or references. The return type for each generator
+   *   function can be a string or undefined.
    *
-   * When left unset, the base tree is the tree of the base ref.
+   * The expected return types convey specific meanings:
+   * - If the return type is a string, it indicates a valid candidate branch
+   *   name or reference to be used.
+   * - If the return type is undefined, it suggests using a fallback reference
+   *   or the default branch.
+   * - If the return type is null, it signifies the creation of a completely
+   *   empty new branch.
+   *
+   * Overall, the `baseRef` function serves the purpose of specifying and
+   * overriding the base reference for a branch, with different return types
+   * conveying different actions related to branch handling.
    */
-  baseTree(
-    shaOrSHAGenerate: Generate<string, []>,
-    baseRefOrBaseRefGenerate: Generate<string | undefined, []>,
+  baseRef(
+    refOrRefGenerate?: Generate<string | undefined | null, []>,
+    ...fallbackRefs: Generate<string | undefined, []>[]
   ): this;
-
-  /**
-   * baseRef sets the base ref.
-   *
-   * Subsequent calls to base will override the previous value.
-   *
-   * When left unset, the base ref is the default branch.
-   */
-  baseRef(baseRefOrBaseRefGenerate: Generate<string | undefined, []>): this;
 
   /**
    * file sets a file blob.


### PR DESCRIPTION
Arguments have been added to some builder methods for aiding in the process of checking if a branch is created before working on it. This is very common in the "createTree" and "createCommit" Codemod operations.

### Affected methods

- `GitHubCreateCommitBuilderInterface.parentRef`
- `GitHubCreateTreeBuilderInterface.baseRef`

Resolves #16.